### PR TITLE
Add parseFloat and fix to 1st decimal

### DIFF
--- a/server/models/utils.js
+++ b/server/models/utils.js
@@ -22,7 +22,7 @@ function transformVehicleData(data){
         if(name === "Model Year"){
             accu["Year"] = val.Value
         } else if(name === "Displacement (L)"){
-            accu["EngineSize"] = `${val.Value}L`
+            accu["EngineSize"] = `${parseFloat(val.Value).toFixed(1)}L`
         } else {
             accu[name] = val.Value
         }


### PR DESCRIPTION
Fixes to the first decimal place for proper engine size rather than having random floats with multiple digits after the decimal. Simple change.