### PR TITLE
Change sync issues from grabbing in localstorage

### DIFF
--- a/client/.eslintrc.cjs
+++ b/client/.eslintrc.cjs
@@ -16,5 +16,8 @@ module.exports = {
       'warn',
       { allowConstantExport: true },
     ],
+    'react/prop-types': [1, { skipUndeclared: true}],
+    'no-unused-vars': ['error', { args: 'none', varsIgnorePattern: '[rR]eact'}],
+    'react/no-unescaped-entities': ['error', { forbid: ['>', '"', '}']}]
   },
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -11,6 +11,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.5.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@loadable/component": "^5.16.3",
+        "jwt-decode": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router": "^6.21.3",
@@ -3497,6 +3498,14 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/levn": {

--- a/client/package.json
+++ b/client/package.json
@@ -13,6 +13,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.5.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@loadable/component": "^5.16.3",
+    "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router": "^6.21.3",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -15,7 +15,7 @@ function App() {
     let decoded;
   if(token) {
     decoded = jwtDecode(token)
-    navigate(`user/${decoded.id}`)
+    navigate(`user/${decoded.id}`, { replace: true })
   }
     setLoading(false)
   },[])

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -10,6 +10,16 @@ function App() {
   const navigate = useNavigate()
   const [loading, setLoading] = useState(true)
 
+  useEffect(() => {
+    const token = localStorage.getItem('token')
+    let decoded;
+  if(token) {
+    decoded = jwtDecode(token)
+    navigate(`user/${decoded.id}`)
+  }
+    setLoading(false)
+  },[])
+
   return (
     <div className='app font-mono w-full'>
       <Header />

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,6 +1,8 @@
-import React, {Suspense} from 'react' 
+import { Suspense, useEffect, useState } from 'react'
 import './App.css';
 import loadable from '@loadable/component';
+import { jwtDecode } from 'jwt-decode'
+import { useNavigate } from 'react-router';
 const Header = loadable(() => import('./components/Header'))
 const Outlet = loadable(() => import('react-router-dom').then(module => ({default : module.Outlet})))
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -20,6 +20,15 @@ function App() {
     setLoading(false)
   },[])
 
+  if(loading) {
+    return(
+      <div>
+        <Header />
+        ...loading
+      </div>
+    )
+  }
+
   return (
     <div className='app font-mono w-full'>
       <Header />

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -7,6 +7,8 @@ const Header = loadable(() => import('./components/Header'))
 const Outlet = loadable(() => import('react-router-dom').then(module => ({default : module.Outlet})))
 
 function App() {
+  const navigate = useNavigate()
+  const [loading, setLoading] = useState(true)
 
   return (
     <div className='app font-mono w-full'>

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,11 +1,14 @@
 import React from "react";
 import { Link, useLocation, useParams } from "react-router-dom";
 import Logout from "./Logout";
+import { useAuth } from "../hooks/useAuth";
 
 export default function Header(props) {
   const { userId } = useParams();
   const location = useLocation();
-  let toggleLogin = !localStorage.getItem("token") ? (
+  const auth = useAuth()
+
+  let toggleLogin = !auth ? (
     <Link
       to="login"
       className={`p-4 ${
@@ -17,7 +20,7 @@ export default function Header(props) {
   ) : (
     <Logout />
   );
-  let toggleHome = localStorage.getItem("token") ? `user/${userId}` : "/";
+  let toggleHome = auth ? `user/${userId}` : "/";
 
   return (
     <header className="p-4 bg-sky-700 flex sticky top-0 min-w-max text-white font-semibold">

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -6,6 +6,10 @@ import { useAuth } from "../hooks/useAuth";
 export default function Header(props) {
   const auth = useAuth()
 
+  function activeLink({ isActive }) {
+    return isActive ? 'p-4 underline underline-offset-4' : 'p-4'
+  }
+
   let toggleLogin = !auth ? (
     <Link
       to="login"

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -4,8 +4,6 @@ import Logout from "./Logout";
 import { useAuth } from "../hooks/useAuth";
 
 export default function Header(props) {
-  const { userId } = useParams();
-  const location = useLocation();
   const auth = useAuth()
 
   let toggleLogin = !auth ? (
@@ -20,7 +18,7 @@ export default function Header(props) {
   ) : (
     <Logout />
   );
-  let toggleHome = auth ? `user/${userId}` : "/";
+  let toggleHome = auth ? `user/${auth.id}` : "/";
 
   return (
     <header className="p-4 bg-sky-700 flex sticky top-0 min-w-max text-white font-semibold">

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -11,12 +11,12 @@ export default function Header(props) {
   }
 
   let toggleLogin = !auth ? (
-    <Link
+    <NavLink
       to="login"
       className={activeLink}
     >
       Login
-    </Link>
+    </NavLink>
   ) : (
     <Logout />
   );
@@ -25,27 +25,27 @@ export default function Header(props) {
   return (
     <header className="p-4 bg-sky-700 flex sticky top-0 min-w-max text-white font-semibold">
       <nav className="flex basis-full justify-around">
-        <Link
+        <NavLink
           to={toggleHome}
           className={activeLink}
         >
           Home
-        </Link>
+        </NavLink>
         {toggleLogin}
-        {!localStorage.getItem("token") && (
-          <Link
+        {!auth && (
+          <NavLink
             to="register"
             className={activeLink}
           >
             Register
-          </Link>
+          </NavLink>
         )}
-        <Link
+        <NavLink
           to="about"
           className={activeLink}
         >
           About
-        </Link>
+        </NavLink>
       </nav>
     </header>
   );

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Link, useLocation, useParams } from "react-router-dom";
+import { NavLink } from "react-router-dom";
 import Logout from "./Logout";
 import { useAuth } from "../hooks/useAuth";
 
@@ -13,9 +13,7 @@ export default function Header(props) {
   let toggleLogin = !auth ? (
     <Link
       to="login"
-      className={`p-4 ${
-        location.pathname === "/login" ? "underline underline-offset-4" : ""
-      }`}
+      className={activeLink}
     >
       Login
     </Link>
@@ -29,9 +27,7 @@ export default function Header(props) {
       <nav className="flex basis-full justify-around">
         <Link
           to={toggleHome}
-          className={`p-4 ${
-            location.pathname === "/" ? "underline underline-offset-4" : ""
-          }`}
+          className={activeLink}
         >
           Home
         </Link>
@@ -39,20 +35,14 @@ export default function Header(props) {
         {!localStorage.getItem("token") && (
           <Link
             to="register"
-            className={`p-4 ${
-              location.pathname === "/register"
-                ? "underline underline-offset-4"
-                : ""
-            }`}
+            className={activeLink}
           >
             Register
           </Link>
         )}
         <Link
           to="about"
-          className={`p-4 ${
-            location.pathname === "/about" ? "underline underline-offset-4" : ""
-          }`}
+          className={activeLink}
         >
           About
         </Link>

--- a/client/src/hooks/useAuth.js
+++ b/client/src/hooks/useAuth.js
@@ -1,0 +1,6 @@
+import { useRouteLoaderData } from 'react-router-dom'
+
+export function useAuth() {
+    const user = useRouteLoaderData('root')
+    return user
+}

--- a/server/models/repairOrderModel.js
+++ b/server/models/repairOrderModel.js
@@ -27,7 +27,7 @@ const RepairOrders = mongoose.model(
   RepairOrderSchema,
   "RepairOrders"
 );
-
+// commit test change
 // module.exports = RepairOrderSchema;
 
 /**

--- a/server/models/repairOrderModel.js
+++ b/server/models/repairOrderModel.js
@@ -27,7 +27,7 @@ const RepairOrders = mongoose.model(
   RepairOrderSchema,
   "RepairOrders"
 );
-// commit test change
+// commit test change new test
 // module.exports = RepairOrderSchema;
 
 /**

--- a/server/models/repairOrderModel.js
+++ b/server/models/repairOrderModel.js
@@ -27,7 +27,7 @@ const RepairOrders = mongoose.model(
   RepairOrderSchema,
   "RepairOrders"
 );
-// commit test change new test
+
 // module.exports = RepairOrderSchema;
 
 /**


### PR DESCRIPTION
Some things were conditionally checked trying to sync with localStorage to conditionally render components based on a user being available. However the root private route has the user available when it is rendered. Changing from 
```js
localStorage.getItem('token') && //condition
```
to check for null or a value, we can use the root loader data returned in the private route globally from the `useRouteLoaderData` hook provided by RR
```js
const user = useRoutLoaderData('root')
```
where `'root'` is the id of the route to hook into the needed data, we can ensure that, while the private route(s) are rendered, it will have a consistent login state and eliminate the need for a lot of defensive coding for syncing state. The only caveat is that if the user were to navigate to routes that were public, the user would be lost. So we will have to guard against that scenario and ensure that once a user is logged out... no public routes will be navigable.

Also, to provide a better UX, when the app is mounted and the user has already been logged in, we can grab the token from local storage (if it exists) and decode it with `jwt-decode` to grab the user id in the payload and navigate the user to the dashboard
```js
const function App() {
  const navigate = useNavigate()
  //set the initial state to loading when the app mounts
  //so that no unwanted page flashing occurs
  const [loading, setLoading] = useState(true)
  
  useEffect(() => {
    const token = localStorage.getItem('token')
    let decoded; //initialize the decoded token and reassign
    //we have to check if the token exists before decoding
    if(token) {
      // we don't want the header, only the payload
      decoded = jwtDecode(token, { header: false }
     // since the logged in root route is user/:id we need to grab the id from the
     // token and navigate on mount
      navigate(`user/${decoded.id}`, { replace: true })
    }
    // we can allow some fall through and change the loading state
    //even if the token doesn't exist to render the public routes or login
    setLoading(false)
  }, [])

  if(loading) {
    //return a loading state
  }

  return (
    // return the header and outlet for the children
  )
}
```
Now, if the token exists and is not expired, the app will navigate to the dashboard route on mount. If the token is expired, the network request will be a 401 response and the user will be redirected to the login route. 

We can create a naive `useAuth` hook based on the protected route being rendered. 
```js
export function useAuth() {
  const user = useRouteLoaderData('root') // grab the protected root route information
  // user will be available or undefined/null
  return user
}
```
